### PR TITLE
Fix supertype overrides

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNBroadcastPackage.java
+++ b/android/src/main/java/com/reactlibrary/RNBroadcastPackage.java
@@ -15,17 +15,14 @@ import com.facebook.react.uimanager.ViewManager;
 import com.facebook.react.bridge.JavaScriptModule;
 public class RNBroadcastPackage implements ReactPackage {
 
-    @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         return Collections.emptyList();
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }
 
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Arrays.<ViewManager>asList(
                 new RNBroadcastViewManager()


### PR DESCRIPTION
node_modules/react-native-broadcast/android/src/main/java/com/reactlibrary/RNBroadcastPackage.java:23: error: method does not override or implement a method from a supertype
    @Override
    ^
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.